### PR TITLE
Android Compatibility

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/LazySodium.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/LazySodium.java
@@ -38,7 +38,7 @@ public abstract class LazySodium implements
         KeyExchange.Native, KeyExchange.Lazy,
         KeyDerivation.Native, KeyDerivation.Lazy  {
 
-    protected Charset charset = StandardCharsets.UTF_8;
+    protected Charset charset = Charset.forName("UTF-8");
 
 
     public LazySodium() {


### PR DESCRIPTION
Removed usage of classes that do not exist on Android devices below
Oreo (API 26). Now compatible back to Android Jelly Bean (API 16).

For #30.