### PR TITLE
Fix documentation for KeyPair cryptoKxServerSessionKeys method

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/interfaces/KeyExchange.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/interfaces/KeyExchange.java
@@ -157,8 +157,8 @@ public interface KeyExchange {
         /**
          * Generate a server's session keys. This should
          * be performed on the server.
-         * @param serverKeyPair Provide the server's public key only.
-         * @param clientKeyPair Provide the client's public and private key.
+         * @param serverKeyPair Provide the server's public and private key.
+         * @param clientKeyPair Provide the client's public key only.
          * @return Session keys.
          * @throws SodiumException Not provided the correct keys, or generation
          * of session keys failed.


### PR DESCRIPTION
The description for the serverKeyPair and clientKeyPair parameters were reversed - it stated that the only the server's public key should be provided but the client's public and private keys should be, which is incorrect. I assume a copy-paste error =D.