### PR TITLE
Fix Mode.PREFER_SYSTEM switch to bundled version

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/SodiumJava.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/SodiumJava.java
@@ -8,7 +8,6 @@
 
 package com.goterl.lazycode.lazysodium;
 
-import co.libly.resourceloader.SharedLibraryLoader;
 import com.goterl.lazycode.lazysodium.utils.LibraryLoader;
 
 import java.util.ArrayList;
@@ -40,7 +39,6 @@ public class SodiumJava extends Sodium {
         new LibraryLoader(getClassesToRegister()).loadAbsolutePath(absolutePath);
         onRegistered();
     }
-
 
     // Scrypt
 

--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/LibraryLoader.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/LibraryLoader.java
@@ -96,7 +96,13 @@ public final class LibraryLoader {
     }
 
     public void loadSystemLibrary(String library) {
-        SharedLibraryLoader.get().loadSystemLibrary(library, classes);
+        try {
+            SharedLibraryLoader.get().loadSystemLibrary(library, classes);
+        } catch (UnsatisfiedLinkError e) {
+            String message = String.format("Failed to load the system library using (%s)",
+                library);
+            throw new LibraryLoadingException(message);
+        }
     }
 
     public void loadAbsolutePath(String absPath) {


### PR DESCRIPTION
`Mode.PREFER_SYSTEM` didn't switch to bundled version if it failed, this should fix that.
The issue is that after `4.1.0` changes `LibraryLoadingException` is not thrown anymore, so `loadBundledLibrary` is never invoked.