### PR TITLE
Fix "prefer system" library loading mode

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/LibraryLoader.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/LibraryLoader.java
@@ -79,7 +79,7 @@ public final class LibraryLoader {
             case PREFER_SYSTEM:
                 try {
                     loadSystemLibrary(systemFallBack);
-                } catch (Exception suppressed) {
+                } catch (Throwable suppressed) {
                     // Attempt to load the bundled
                     loadBundledLibrary();
                 }


### PR DESCRIPTION
Resource loader throws `UnsatisfiedLinkError` if it is unable to load the library, which is not caught by `catch (Exception e) { ... }`. This PR fixes that.