### PR TITLE
Add lazy methods for handling sealed boxes

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/LazySodium.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/LazySodium.java
@@ -1036,6 +1036,33 @@ public abstract class LazySodium implements
         return new DetachedDecrypt(message, mac);
     }
 
+    @Override
+    public String cryptoBoxSealEasy(String message, Key publicKey) throws SodiumException {
+        byte[] keyBytes = publicKey.getAsBytes();
+        byte[] messageBytes = bytes(message);
+        byte[] cipher = new byte[Box.SEALBYTES + messageBytes.length];
+
+        if (!cryptoBoxSeal(cipher, messageBytes, messageBytes.length, keyBytes)) {
+            throw new SodiumException("Could not encrypt message.");
+        }
+        return toHex(cipher);
+    }
+
+    @Override
+    public String cryptoBoxSealOpenEasy(String cipherText, KeyPair keyPair) throws SodiumException {
+        byte[] cipher = toBin(cipherText);
+        byte[] message = new byte[cipher.length - Box.SEALBYTES];
+
+        boolean res = cryptoBoxSealOpen(message,
+                                        cipher,
+                                        cipher.length,
+                                        keyPair.getPublicKey().getAsBytes(),
+                                        keyPair.getSecretKey().getAsBytes());
+        if (!res) {
+            throw new SodiumException("Could not decrypt your message.");
+        }
+        return str(message);
+    }
 
     //// -------------------------------------------|
     //// CRYPTO SIGN

--- a/src/main/java/com/goterl/lazycode/lazysodium/interfaces/Box.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/interfaces/Box.java
@@ -13,6 +13,7 @@ import com.goterl.lazycode.lazysodium.exceptions.SodiumException;
 import com.goterl.lazycode.lazysodium.utils.BaseChecker;
 import com.goterl.lazycode.lazysodium.utils.DetachedDecrypt;
 import com.goterl.lazycode.lazysodium.utils.DetachedEncrypt;
+import com.goterl.lazycode.lazysodium.utils.Key;
 import com.goterl.lazycode.lazysodium.utils.KeyPair;
 
 public interface Box {
@@ -262,6 +263,22 @@ public interface Box {
                                                      String sharedSecretKey) throws SodiumException;
 
 
+        /**
+         * Encrypts a message.
+         * @param message The message.
+         * @param publicKey A public key.
+         * @return The encrypted {@link Helpers.Lazy#sodiumBin2Hex(byte[])}'ified cipher text.
+         */
+        String cryptoBoxSealEasy(String message, Key publicKey) throws SodiumException;
+
+        /**
+         * Decrypts a previously encrypted message.
+         * @param cipherText Encrypted via {@link #cryptoBoxSealEasy(String, Key)}
+         *                   and then {@link Helpers.Lazy#sodiumBin2Hex(byte[])}'ified.
+         * @param keyPair A keypair.
+         * @return The message.
+         */
+        String cryptoBoxSealOpenEasy(String cipherText, KeyPair keyPair) throws SodiumException;
     }
 
 

--- a/src/test/java/com/goterl/lazycode/lazysodium/BoxTest.java
+++ b/src/test/java/com/goterl/lazycode/lazysodium/BoxTest.java
@@ -130,5 +130,20 @@ public class BoxTest extends BaseTest {
         TestCase.assertEquals(message, lazySodium.str(decryptDet.getMessage()));
     }
 
+    @Test
+    public void sealMessage() throws SodiumException {
+        String message = "This should get encrypted";
 
+        // Generate the keypair
+        KeyPair keyPair = cryptoBoxLazy.cryptoBoxKeypair();
+
+        // Encrypt the message
+        String encrypted = cryptoBoxLazy.cryptoBoxSealEasy(message, keyPair.getPublicKey());
+
+        // Now we can decrypt the encrypted message.
+        String decryptedMessage = cryptoBoxLazy.cryptoBoxSealOpenEasy(encrypted, keyPair);
+
+        // Public-private key encryption complete!
+        TestCase.assertEquals(message, decryptedMessage);
+    }
 }


### PR DESCRIPTION
This adds the to methods `cryptoBoxSealEasy` and `cryptoBoxSealOpenEasy` to the interface `Box.Lazy` to handle sealed boxes the lazy way.