### PR TITLE
Support different message encoding formats

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/LazySodiumJava.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/LazySodiumJava.java
@@ -12,6 +12,7 @@ import com.goterl.lazycode.lazysodium.exceptions.SodiumException;
 import com.goterl.lazycode.lazysodium.interfaces.Scrypt;
 import com.goterl.lazycode.lazysodium.interfaces.StreamJava;
 import com.goterl.lazycode.lazysodium.utils.Key;
+import com.goterl.lazycode.lazysodium.utils.MessageEncoder;
 
 import java.nio.charset.Charset;
 
@@ -31,6 +32,15 @@ public class LazySodiumJava extends LazySodium implements
         this.sodium = sodium;
     }
 
+    public LazySodiumJava(SodiumJava sodium, MessageEncoder messageEncoder) {
+        super(messageEncoder);
+        this.sodium = sodium;
+    }
+
+    public LazySodiumJava(SodiumJava sodium, Charset charset, MessageEncoder messageEncoder) {
+        super(charset, messageEncoder);
+        this.sodium = sodium;
+    }
 
     @Override
     public boolean cryptoPwHashScryptSalsa208Sha256(byte[] out, long outLen, byte[] password, long passwordLen, byte[] salt, long opsLimit, long memLimit) {
@@ -73,7 +83,7 @@ public class LazySodiumJava extends LazySodium implements
             throw new SodiumException("Could not Scrypt hash your password.");
         }
 
-        return toHex(hash);
+        return messageEncoder.encode(hash);
     }
 
     @Override
@@ -96,12 +106,12 @@ public class LazySodiumJava extends LazySodium implements
             throw new SodiumException("Could not string Scrypt hash your password.");
         }
 
-        return toHex(hash);
+        return messageEncoder.encode(hash);
     }
 
     @Override
     public boolean cryptoPwHashScryptSalsa208Sha256StrVerify(String hash, String password) {
-        byte[] hashBytes = toBin(hash);
+        byte[] hashBytes = messageEncoder.decode(hash);
         byte[] passwordBytes = bytes(password);
 
         // If the end of the hash does not have an null byte,
@@ -210,23 +220,23 @@ public class LazySodiumJava extends LazySodium implements
     @Override
     public String cryptoStreamXor(String message, byte[] nonce, Key key, StreamJava.Method method) {
         byte[] mBytes = bytes(message);
-        return toHex(cryptoStreamDefaultXor(mBytes, nonce, key, method));
+        return messageEncoder.encode(cryptoStreamDefaultXor(mBytes, nonce, key, method));
     }
 
     @Override
     public String cryptoStreamXorDecrypt(String cipher, byte[] nonce, Key key, StreamJava.Method method) {
-        return str(cryptoStreamDefaultXor(toBin(cipher), nonce, key, method));
+        return str(cryptoStreamDefaultXor(messageEncoder.decode(cipher), nonce, key, method));
     }
 
     @Override
     public String cryptoStreamXorIc(String message, byte[] nonce, long ic, Key key, StreamJava.Method method) {
         byte[] mBytes = bytes(message);
-        return toHex(cryptoStreamDefaultXorIc(mBytes, nonce, ic, key, method));
+        return messageEncoder.encode(cryptoStreamDefaultXorIc(mBytes, nonce, ic, key, method));
     }
 
     @Override
     public String cryptoStreamXorIcDecrypt(String cipher, byte[] nonce, long ic, Key key, StreamJava.Method method) {
-        return str(cryptoStreamDefaultXorIc(toBin(cipher), nonce, ic, key, method));
+        return str(cryptoStreamDefaultXorIc(messageEncoder.decode(cipher), nonce, ic, key, method));
     }
 
     private byte[] cryptoStreamDefaultXor(byte[] messageBytes, byte[] nonce, Key key, StreamJava.Method method) {

--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/Base64MessageEncoder.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/Base64MessageEncoder.java
@@ -1,0 +1,16 @@
+package com.goterl.lazycode.lazysodium.utils;
+
+import java.util.Base64;
+
+public class Base64MessageEncoder implements MessageEncoder {
+
+    @Override
+    public String encode(byte[] cipher) {
+        return Base64.getEncoder().encodeToString(cipher);
+    }
+
+    @Override
+    public byte[] decode(String cipherText) {
+        return Base64.getDecoder().decode(cipherText);
+    }
+}

--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/HexMessageEncoder.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/HexMessageEncoder.java
@@ -1,0 +1,16 @@
+package com.goterl.lazycode.lazysodium.utils;
+
+import com.goterl.lazycode.lazysodium.LazySodium;
+
+public class HexMessageEncoder implements MessageEncoder {
+
+    @Override
+    public String encode(byte[] cipher) {
+        return LazySodium.toHex(cipher);
+    }
+
+    @Override
+    public byte[] decode(String cipherText) {
+        return LazySodium.toBin(cipherText);
+    }
+}

--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/Key.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/Key.java
@@ -11,6 +11,7 @@ package com.goterl.lazycode.lazysodium.utils;
 import com.goterl.lazycode.lazysodium.LazySodium;
 
 import java.nio.charset.Charset;
+import java.util.Base64;
 
 public class Key {
     private byte[] key;
@@ -43,6 +44,15 @@ public class Key {
      */
     public static Key fromHexString(String hexString) {
         return new Key(LazySodium.toBin(hexString));
+    }
+
+    /**
+     * Create a Key from a base64 string.
+     * @param base64String A base64 encoded string.
+     * @return A new Key.
+     */
+    public static Key fromBase64String(String base64String) {
+        return new Key(Base64.getDecoder().decode(base64String));
     }
 
     /**

--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/MessageEncoder.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/MessageEncoder.java
@@ -1,0 +1,6 @@
+package com.goterl.lazycode.lazysodium.utils;
+
+public interface MessageEncoder {
+    String encode(byte[] cipher);
+    byte[] decode(String cipherText);
+}

--- a/src/test/java/com/goterl/lazycode/lazysodium/utils/Base64MessageEncoderTest.java
+++ b/src/test/java/com/goterl/lazycode/lazysodium/utils/Base64MessageEncoderTest.java
@@ -1,0 +1,18 @@
+package com.goterl.lazycode.lazysodium.utils;
+
+import com.goterl.lazycode.lazysodium.BaseTest;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class Base64MessageEncoderTest extends BaseTest {
+
+    @Test
+    public void decodeEqualsEncode() {
+        Base64MessageEncoder encoder = new Base64MessageEncoder();
+
+        String cipherText = "YS1iYXNlNjQtZW5jb2RlZC1zdHJpbmcK";
+        byte[] cipher = encoder.decode(cipherText);
+
+        TestCase.assertEquals(cipherText, encoder.encode(cipher));
+    }
+}

--- a/src/test/java/com/goterl/lazycode/lazysodium/utils/HexMessageEncoderTest.java
+++ b/src/test/java/com/goterl/lazycode/lazysodium/utils/HexMessageEncoderTest.java
@@ -1,0 +1,18 @@
+package com.goterl.lazycode.lazysodium.utils;
+
+import com.goterl.lazycode.lazysodium.BaseTest;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class HexMessageEncoderTest extends BaseTest {
+
+    @Test
+    public void decodeEqualsEncode() {
+        HexMessageEncoder encoder = new HexMessageEncoder();
+
+        String cipherText = "612D6865782D656E636F6465642D737472696E67";
+        byte[] cipher = encoder.decode(cipherText);
+
+        TestCase.assertEquals(cipherText, encoder.encode(cipher));
+    }
+}


### PR DESCRIPTION
This PR adds support for different message encoding formats (hex, base64). The current implementation just supports hex when using the lazy methods but it's quite common to use the base64 encoding for encrypted content.
To not break the public API of LazySodium this PR doesn't touch any of the static methods for the hex encoding it just uses them in the `HexMessageEncoder`.