### PR TITLE
Open to public getSodiumPathInResources()

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/LibraryLoader.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/LibraryLoader.java
@@ -136,7 +136,7 @@ public final class LibraryLoader {
     /**
      * Returns the absolute path to sodium library inside JAR (beginning with '/'), e.g. /linux/libsodium.so.
      */
-    private static String getSodiumPathInResources() {
+    public static String getSodiumPathInResources() {
         boolean is64Bit = Native.POINTER_SIZE == 8;
         if (Platform.isWindows()) {
             if (is64Bit) {


### PR DESCRIPTION
Since there is some problem with bundle version when running inside fatjar (for example default spring-boot mode).

Workaround will be letting devs to load bundle native lib, but in order to do not copy-past the same platform detection logic, opening `getSodiumPathInResources()` to public will help

related to #73