### PR TITLE
Fix return type for randombytes_random and _uniform

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/LazySodium.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/LazySodium.java
@@ -147,7 +147,7 @@ public abstract class LazySodium implements
     //// -------------------------------------------|
 
     @Override
-    public byte randomBytesRandom() {
+    public long randomBytesRandom() {
         return getSodium().randombytes_random();
     }
 
@@ -164,7 +164,7 @@ public abstract class LazySodium implements
     }
 
     @Override
-    public byte randomBytesUniform(int upperBound) {
+    public long randomBytesUniform(int upperBound) {
         return getSodium().randombytes_uniform(upperBound);
     }
 

--- a/src/main/java/com/goterl/lazycode/lazysodium/Sodium.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/Sodium.java
@@ -100,9 +100,9 @@ public class Sodium {
     //// RANDOM
     //// -------------------------------------------|
 
-    public native byte randombytes_random();
+    public native long randombytes_random();
 
-    public native byte randombytes_uniform(int upperBound);
+    public native long randombytes_uniform(int upperBound);
 
     public native void randombytes_buf(byte[] buffer, int size);
 

--- a/src/main/java/com/goterl/lazycode/lazysodium/interfaces/Random.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/interfaces/Random.java
@@ -13,10 +13,10 @@ package com.goterl.lazycode.lazysodium.interfaces;
 public interface Random {
 
     /**
-     * Return a random byte 0 and 0xffffffff included.
+     * Return a unsigned int byte 0 and 0xffffffff included.
      * @return A random byte.
      */
-    byte randomBytesRandom();
+    long randomBytesRandom();
 
     /**
      * Returns an unpredictable value between 0 and upperBound (excluded).
@@ -24,9 +24,9 @@ public interface Random {
      * of the possible output values even when upper_bound is not a power of 2. Note
      * that an upper_bound less than 2 leaves only a single element to be chosen, namely 0.
      * @param upperBound
-     * @return A uniformally random bytes.
+     * @return A uniformly random unsigned int.
      */
-    byte randomBytesUniform(int upperBound);
+    long randomBytesUniform(int upperBound);
 
     /**
      * Get a random number of bytes.


### PR DESCRIPTION
Signature for randombytes_random and randombytes_uniform is uint32 in libsodium but in lazysodium it's byte. This pull request fixes that.

I used long as return type, because the libsodium function return unsigned int.

Fixes #86 