### PR TITLE
Prevent memory access errors in many native calls by adding checks

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/interfaces/KeyDerivation.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/interfaces/KeyDerivation.java
@@ -77,8 +77,8 @@ public interface KeyDerivation {
             return masterKeyLen == KeyDerivation.MASTER_KEY_BYTES;
         }
 
-        public static boolean subKeyIsCorrect(int lengthOfSubkey) {
-            return isBetween(lengthOfSubkey, BYTES_MIN, BYTES_MAX);
+        public static void checkSubKeyLength(int subkeyLen) {
+            checkBetween("subkey length", subkeyLen, BYTES_MIN, BYTES_MAX);
         }
 
         public static boolean contextIsCorrect(int length) {

--- a/src/main/java/com/goterl/lazycode/lazysodium/interfaces/PwHash.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/interfaces/PwHash.java
@@ -70,37 +70,20 @@ public interface PwHash {
 
 
     class Checker extends BaseChecker {
-        public static boolean saltIsCorrect(long saltLen) {
-            return correctLen(saltLen, PwHash.SALTBYTES);
-        }
-        public static boolean passwordIsCorrect(long len) {
-            return isBetween(len, PwHash.PASSWD_MIN, PwHash.PASSWD_MAX);
-        }
-        public static boolean opsLimitIsCorrect(long ops) {
-            return isBetween(ops, PwHash.OPSLIMIT_MIN, PwHash.OPSLIMIT_MAX);
-        }
-        public static boolean memLimitIsCorrect(NativeLong len) {
-            return isBetween(len, PwHash.MEMLIMIT_MIN, PwHash.MEMLIMIT_MAX);
+        public static void checkPassword(byte[] password) {
+            checkBetween("password length", password.length, PwHash.PASSWD_MIN, PwHash.PASSWD_MAX);
         }
 
-        public static boolean checkAll(long passwordBytesLen,
-                                       long saltBytesLen,
-                                       long opsLimit,
-                                       NativeLong memLimit)
-                throws SodiumException {
-            if (!PwHash.Checker.saltIsCorrect(saltBytesLen)) {
-                throw new SodiumException("The salt provided is not the correct length.");
-            }
-            if (!PwHash.Checker.passwordIsCorrect(passwordBytesLen)) {
-                throw new SodiumException("The password provided is not the correct length.");
-            }
-            if (!PwHash.Checker.opsLimitIsCorrect(opsLimit)) {
-                throw new SodiumException("The opsLimit provided is not the correct value.");
-            }
-            if (!PwHash.Checker.memLimitIsCorrect(memLimit)) {
-                throw new SodiumException("The memLimit provided is not the correct value.");
-            }
-            return true;
+        public static void checkSalt(byte[] salt) {
+            checkEqual("salt length", salt.length, SALTBYTES);
+        }
+
+        public static void checkOpsLimit(long opsLimit) {
+            checkBetween("opsLimit", opsLimit, PwHash.OPSLIMIT_MIN, PwHash.OPSLIMIT_MAX);
+        }
+
+        public static void checkMemLimit(NativeLong memLimit) {
+            checkBetween("memLimit", memLimit, PwHash.MEMLIMIT_MIN, PwHash.MEMLIMIT_MAX);
         }
     }
 

--- a/src/main/java/com/goterl/lazycode/lazysodium/interfaces/SecretStream.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/interfaces/SecretStream.java
@@ -44,8 +44,26 @@ public interface SecretStream {
 
     class Checker extends BaseChecker {
 
-        public static boolean headerCheck(int headerSize) {
-            return headerSize == HEADERBYTES;
+        public static void checkHeader(byte[] header) {
+            checkEqual("secret stream header length", HEADERBYTES, header.length);
+        }
+
+        public static void checkKey(byte[] key) {
+            checkEqual("secret stream key length", KEYBYTES, key.length);
+        }
+
+        public static void checkPush(byte[] message, long messageLen, byte[] cipher) {
+            checkArrayLength("message bytes", message, messageLen);
+            if (cipher.length < messageLen + ABYTES) {
+                throw new IllegalArgumentException("Cipher array too small for messageLen + header");
+            }
+        }
+
+        public static void checkPull(byte[] cipher, long cipherLen, byte[] message) {
+            checkArrayLength("message bytes", cipher, cipherLen);
+            if (message.length < cipherLen - ABYTES) {
+                throw new IllegalArgumentException("Message array too small for cipherLen - header");
+            }
         }
 
     }

--- a/src/main/java/com/goterl/lazycode/lazysodium/utils/BaseChecker.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/utils/BaseChecker.java
@@ -12,17 +12,55 @@ import com.sun.jna.NativeLong;
 
 public class BaseChecker {
 
+    public static void checkBetween(String name, long num, long min, long max) {
+        if (num < min) {
+            throw new IllegalArgumentException("Provided " + name + " is below minimum bound.");
+        }
+        if (num > max) {
+            throw new IllegalArgumentException("Provided " + name + " is above maximum bound.");
+        }
+    }
+
+    public static void checkBetween(String name, NativeLong num, NativeLong min, NativeLong max) {
+        checkBetween(name, num.longValue(), min.longValue(), max.longValue());
+    }
+
     public static boolean isBetween(long num, long min, long max) {
         return min <= num && num <= max;
     }
 
-    public static boolean isBetween(NativeLong num, NativeLong min, NativeLong max) {
-        long number = num.longValue();
-        return min.longValue() <= number && number <= max.longValue();
-    }
-
     public static boolean correctLen(long num, long len) {
         return num == len;
+    }
+
+    /**
+     * Throw if provided value does not match an expected value.
+     */
+    public static void checkEqual(String name, int expected, int actual) {
+        if (actual != expected) {
+            // Neither value is reported, in case this is passed sensitive
+            // values, even though most uses are likely for header lengths and
+            // similar.
+            throw new IllegalArgumentException(
+                "Provided " + name + " did not match expected value");
+        }
+    }
+
+    public static void checkArrayLength(String name, char[] array, long length) {
+        checkArrayLength(name, array.length, length);
+    }
+
+    public static void checkArrayLength(String name, byte[] array, long length) {
+        checkArrayLength(name, array.length, length);
+    }
+
+    private static void checkArrayLength(String name, int arrayLength, long length) {
+        if (length > arrayLength) {
+            throw new IllegalArgumentException("Provided " + name + " array length is larger than array");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("Provided " + name + " array length is negative");
+        }
     }
 
 }


### PR DESCRIPTION
This is not comprehensive coverage, but should take care of a number of
unguarded calls. It comes out of issue #81 in which a call to
`cryptoSecretStreamPush` with an incorrectly sized array lead to a VM
crash.

- Add array checkers to BaseChecker
- Simplify some existing checks by moving the `throw` into the check
  method; add reporting of which variable failed a check
- Add checkers for SecretStream
- Split PwHash.Checker.checkAll into individual check calls to reduce
  chance of positional argument errors