### PR TITLE
Downgrade slf4j-api to 1.7.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ sourceSets {
 dependencies {
     implementation 'net.java.dev.jna:jna:5.5.0'
     implementation 'co.libly:resource-loader:1.3.10'
-    implementation 'org.slf4j:slf4j-api:2.0.0-alpha1'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.28.2'
 }


### PR DESCRIPTION
Closes #93 

Use of alpha version is not recommended, and will lower adoption of this project. The version `1.7.30` is the de-facto standard for slf4j, especially for what it's used. 