### PR TITLE
Accept a JNA Pointer in place of a byte array for some low-level methods

### DIFF
--- a/src/main/java/com/goterl/lazysodium/LazySodium.java
+++ b/src/main/java/com/goterl/lazysodium/LazySodium.java
@@ -206,13 +206,28 @@ public abstract class LazySodium implements
     }
 
     @Override
+    public boolean sodiumMemZero(Pointer pnt, int len) {
+        return successful(getSodium().sodium_memzero(pnt, len));
+    }
+
+    @Override
     public boolean sodiumMLock(byte[] array, int len) {
         return successful(getSodium().sodium_mlock(array, len));
     }
 
     @Override
+    public boolean sodiumMLock(Pointer pnt, int len) {
+        return successful(getSodium().sodium_mlock(pnt, len));
+    }
+
+    @Override
     public boolean sodiumMUnlock(byte[] array, int len) {
         return successful(getSodium().sodium_munlock(array, len));
+    }
+
+    @Override
+    public boolean sodiumMUnlock(Pointer pnt, int len) {
+        return successful(getSodium().sodium_munlock(pnt, len));
     }
 
     @Override

--- a/src/main/java/com/goterl/lazysodium/Sodium.java
+++ b/src/main/java/com/goterl/lazysodium/Sodium.java
@@ -73,8 +73,11 @@ public class Sodium {
     //// -------------------------------------------|
 
     public native int sodium_memzero(byte[] pnt, int len);
+    public native int sodium_memzero(Pointer pnt, int len);
     public native int sodium_mlock(byte[] addr, int len);
+    public native int sodium_mlock(Pointer addr, int len);
     public native int sodium_munlock(byte[] addr, int len);
+    public native int sodium_munlock(Pointer addr, int len);
     public native Pointer sodium_malloc(int size);
     public native Pointer sodium_allocarray(int count, int size);
     public native void sodium_free(Pointer p);

--- a/src/main/java/com/goterl/lazysodium/interfaces/SecureMemory.java
+++ b/src/main/java/com/goterl/lazysodium/interfaces/SecureMemory.java
@@ -26,6 +26,15 @@ public interface SecureMemory {
         boolean sodiumMemZero(byte[] pnt, int len);
 
         /**
+         * The sodium_memzero() function tries to effectively zero len bytes starting at pnt,
+         * even if optimizations are being applied to the code.
+         * @param pnt The pointer to zero out.
+         * @param len How many bytes to zero out.
+         * @return True if zeroed
+         */
+        boolean sodiumMemZero(Pointer pnt, int len);
+
+        /**
          * Locks at least len bytes of memory from the array.
          * This can help avoid swapping sensitive data to disk.
          * @param array Array to lock.
@@ -35,12 +44,29 @@ public interface SecureMemory {
         boolean sodiumMLock(byte[] array, int len);
 
         /**
+         * Locks at least len bytes of memory from the pointer.
+         * This can help avoid swapping sensitive data to disk.
+         * @param pnt pointer to the memory to lock.
+         * @param len Number of bytes to lock.
+         * @return True if locked, false otherwise.
+         */
+        boolean sodiumMLock(Pointer pnt, int len);
+
+        /**
          * Unlocks at least len bytes of memory from the array.
          * @param array Array to unlock.
          * @param len Number of bytes to unlock.
          * @return True if unlocked, false otherwise.
          */
         boolean sodiumMUnlock(byte[] array, int len);
+
+        /**
+         * Unlocks at least len bytes of memory from the pointer.
+         * @param pnt pointer to the memory to unlock.
+         * @param len Number of bytes to unlock.
+         * @return True if locked, false otherwise.
+         */
+        boolean sodiumMUnlock(Pointer pnt, int len);
 
         /**
          * Returns a pointer from which exactly

--- a/src/test/java/com/goterl/lazysodium/SecureMemoryTest.java
+++ b/src/test/java/com/goterl/lazysodium/SecureMemoryTest.java
@@ -6,13 +6,14 @@
  * file, you can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package com.goterl.lazysodium;import com.sun.jna.Pointer;
+package com.goterl.lazysodium;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
 import junit.framework.TestCase;
 import org.junit.Test;
 
 public class SecureMemoryTest extends BaseTest {
-
-
     @Test
     public void memZero() {
         byte[] b = new byte[] { 4, 2, 2, 1 };
@@ -21,11 +22,42 @@ public class SecureMemoryTest extends BaseTest {
     }
 
     @Test
+    public void memZeroPtr() {
+        Pointer p = new Memory(32);
+        p.write(0, lazySodium.randomBytesBuf(32), 0, 32);
+        TestCase.assertFalse(isZero(p.getByteArray(0, 32)));
+
+        boolean res = lazySodium.sodiumMemZero(p, 32);
+
+        TestCase.assertTrue(res);
+        TestCase.assertTrue(isZero(p.getByteArray(0, 32)));
+
+    }
+
+    @Test
     public void mLock() {
         byte[] b = new byte[] { 4, 5, 2, 1 };
+
         boolean res = lazySodium.sodiumMLock(b, b.length);
         boolean res2 = lazySodium.sodiumMUnlock(b, b.length);
+
+        TestCase.assertTrue(res);
+        TestCase.assertTrue(res2);
         TestCase.assertTrue(isZero(b));
+    }
+
+    @Test
+    public void mLockPtr() {
+        Pointer p = new Memory(32);
+        p.write(0, lazySodium.randomBytesBuf(32), 0, 32);
+        TestCase.assertFalse(isZero(p.getByteArray(0, 32)));
+
+        boolean res = lazySodium.sodiumMLock(p, 32);
+        boolean res2 = lazySodium.sodiumMUnlock(p, 32);
+
+        TestCase.assertTrue(res);
+        TestCase.assertTrue(res2);
+        TestCase.assertTrue(isZero(p.getByteArray(0, 32)));
     }
 
     @Test
@@ -37,6 +69,17 @@ public class SecureMemoryTest extends BaseTest {
         byte[] arr = ptr.getByteArray(0, size);
 
         TestCase.assertEquals(arr.length, size);
+    }
+
+    @Test
+    public void allocArray() {
+        int size = 10;
+
+        Pointer ptr = lazySodium.sodiumAllocArray(size, 2);
+
+        byte[] arr = ptr.getByteArray(0, size * 2);
+
+        TestCase.assertEquals(arr.length, size * 2);
     }
 
     @Test


### PR DESCRIPTION
Adds variants of `sodium_memzero`, `sodium_mlock` and `sodium_munlock` that accept a JNA Pointer instead of a byte array.