### PR TITLE
Automatic-Module-Name added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 
+tasks.named('jar') {
+    manifest {
+        attributes('Automatic-Module-Name': 'com.goterl.lazysodium')
+    }
+}
+
+
 task signPom(type: Sign) {
     sign project.file("$buildDir/publications/mavenJava/pom-default.xml")
 


### PR DESCRIPTION
This PR adds "com.goterl.lazysodium" as an automatic module name to the manifest. By doing so the library can better be used in Java 9+ projects that use the module path.