### PR TITLE
Restore target Java 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ group project.ext.groupId
 version = project.ext.version
 
 mainClassName = "com.goterl.lazysodium.LazySodium"
-sourceCompatibility = JavaVersion.VERSION_21
+sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ version = project.ext.version
 
 mainClassName = "com.goterl.lazysodium.LazySodium"
 sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_1_8
 
 sourceSets {
     main {


### PR DESCRIPTION
Since this library is a native wrapper, there is no benefit to target Java 21 bytecode version.


Fix #140